### PR TITLE
Added an ability to use styles defined in App.xaml within Xamarin.Forms.Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ The extension provides a new `View | Other Windows | Xamarin Forms Player` comma
 
 ![Visual Studio ToolWindow](https://raw.githubusercontent.com/MobileEssentials/FormsPlayer/master/src/FormsPlayer.Vsix/Resources/screen-1.png)
 
-To get the Xamarin.Forms.Player app on the device, either build it yourself [from source](https://github.com/MobileEssentials/FormsPlayer) or create a new Xamarin.Forms app with whatever references you need to custom controls, control libraries, etc., and install the Xamarin.Forms.Player nuget package in it. Then replace the `new App()` instantiation with `new Xamarin.Forms.Player.App()` instead. That will bring in the player UI and enable all the rendering functionality automatically.
+To get the Xamarin.Forms.Player app on the device, either build it yourself [from source](https://github.com/MobileEssentials/FormsPlayer) or grab a pre-built APK directly from the [Releases](https://github.com/MobileEssentials/FormsPlayer/releases) page (for Android). 
+
+To enable support for custom controls, behaviors, converters, etc. you need to embed `FormsPlayer` in your application. The steps to do so are (the complexity caused by Microsoft.AspNet.SignalR.Client not installable into latest iOS/Android):
+
+1. Update Profile in your PCL project (should be Profile78 to be able to install Microsoft.AspNet.SignalR.Client). This could be done by editing you .csproj in notepad and altering TargetFrameworkProfile value to `<TargetFrameworkProfile>Profile78</TargetFrameworkProfile>`
+2. `Install-Package Microsoft.AspNet.SignalR.Client` into your __PCL project__
+3. `Install-Package Xamarin.Forms.Player2 -pre` into you Android/iOS platform-specific project
+4. Replace the `LoadApplication(new App())` with the following `LoadApplication(new Xamarin.Forms.Player.AppController(new App()).App);` in your AppDelegate/MainActivity.
 
 ![Player on iOS](https://raw.githubusercontent.com/MobileEssentials/FormsPlayer/master/src/FormsPlayer.Vsix/Resources/screen-2.png)
 
 ![Player on Android](https://raw.githubusercontent.com/MobileEssentials/FormsPlayer/master/src/FormsPlayer.Vsix/Resources/screen-3.png)
 
-For Android, you can also grab a pre-built APK directly from the [Releases](https://github.com/MobileEssentials/FormsPlayer/releases) page. The Visual Studio extension should match the version of the application.
+The Visual Studio extension should match the version of the application.

--- a/src/FormsPlayer.Android/FormsPlayer.Android.csproj
+++ b/src/FormsPlayer.Android/FormsPlayer.Android.csproj
@@ -15,8 +15,8 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -76,12 +76,12 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Refractored.Xam.Settings, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xam.Plugins.Settings.1.5.2\lib\MonoAndroid10\Refractored.Xam.Settings.dll</HintPath>
+    <Reference Include="Plugin.Settings, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xam.Plugins.Settings.2.1.0\lib\MonoAndroid10\Plugin.Settings.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Refractored.Xam.Settings.Abstractions, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xam.Plugins.Settings.1.5.2\lib\MonoAndroid10\Refractored.Xam.Settings.Abstractions.dll</HintPath>
+    <Reference Include="Plugin.Settings.Abstractions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xam.Plugins.Settings.2.1.0\lib\MonoAndroid10\Plugin.Settings.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -140,6 +140,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Helpers\Settings.cs" />
     <Compile Include="MainActivity.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -161,7 +162,6 @@
     <AndroidResource Include="Resources\drawable-xxhdpi\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="PluginsHelp\SettingsReadme.txt" />
     <Content Include="Properties\AndroidManifest.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FormsPlayer.Android/Helpers/Settings.cs
+++ b/src/FormsPlayer.Android/Helpers/Settings.cs
@@ -1,11 +1,7 @@
-Ensure that you install NuGet into PCL and see Helpers/Settings.cs
-
-If you are installing this in a normal project and not using a pcl create a new file called Settings.cs or whatever you want and copy this code in:
-
-
-// Helpers/Settings.cs
-using Refractored.Xam.Settings;
-using Refractored.Xam.Settings.Abstractions;
+/*
+// Helpers/Settings.cs This file was automatically added when you installed the Settings Plugin. If you are not using a PCL then comment this file back in to use it.
+using Plugin.Settings;
+using Plugin.Settings.Abstractions;
 
 namespace Xamarin.Forms.Player.Helpers
 {
@@ -45,4 +41,4 @@ namespace Xamarin.Forms.Player.Helpers
     }
 
   }
-}
+}*/

--- a/src/FormsPlayer.Android/Resources/Resource.Designer.cs
+++ b/src/FormsPlayer.Android/Resources/Resource.Designer.cs
@@ -1366,8 +1366,8 @@ namespace Xamarin.Forms.Player
 			// aapt resource value: 0x7f060009
 			public const int abc_text_size_title_material_toolbar = 2131099657;
 			
-			// aapt resource value: 0x7f060050
-			public const int appbar_elevation = 2131099728;
+			// aapt resource value: 0x7f060051
+			public const int appbar_elevation = 2131099729;
 			
 			// aapt resource value: 0x7f060001
 			public const int cardview_compat_inset_shadow = 2131099649;
@@ -1396,44 +1396,44 @@ namespace Xamarin.Forms.Player
 			// aapt resource value: 0x7f060045
 			public const int disabled_alpha_material_light = 2131099717;
 			
-			// aapt resource value: 0x7f060051
-			public const int fab_border_width = 2131099729;
-			
 			// aapt resource value: 0x7f060052
-			public const int fab_content_size = 2131099730;
+			public const int fab_border_width = 2131099730;
 			
 			// aapt resource value: 0x7f060053
-			public const int fab_elevation = 2131099731;
+			public const int fab_content_size = 2131099731;
 			
 			// aapt resource value: 0x7f060054
-			public const int fab_size_mini = 2131099732;
+			public const int fab_elevation = 2131099732;
 			
 			// aapt resource value: 0x7f060055
-			public const int fab_size_normal = 2131099733;
+			public const int fab_size_mini = 2131099733;
 			
 			// aapt resource value: 0x7f060056
-			public const int fab_translation_z_pressed = 2131099734;
+			public const int fab_size_normal = 2131099734;
+			
+			// aapt resource value: 0x7f060057
+			public const int fab_translation_z_pressed = 2131099735;
 			
 			// aapt resource value: 0x7f060000
 			public const int mr_media_route_controller_art_max_height = 2131099648;
 			
-			// aapt resource value: 0x7f060057
-			public const int navigation_elevation = 2131099735;
-			
 			// aapt resource value: 0x7f060058
-			public const int navigation_icon_padding = 2131099736;
+			public const int navigation_elevation = 2131099736;
 			
 			// aapt resource value: 0x7f060059
-			public const int navigation_icon_size = 2131099737;
+			public const int navigation_icon_padding = 2131099737;
 			
 			// aapt resource value: 0x7f06005a
-			public const int navigation_max_width = 2131099738;
+			public const int navigation_icon_size = 2131099738;
 			
 			// aapt resource value: 0x7f06005b
-			public const int navigation_padding_bottom = 2131099739;
+			public const int navigation_max_width = 2131099739;
 			
 			// aapt resource value: 0x7f06005c
-			public const int navigation_padding_top_default = 2131099740;
+			public const int navigation_padding_bottom = 2131099740;
+			
+			// aapt resource value: 0x7f060050
+			public const int navigation_padding_top_default = 2131099728;
 			
 			// aapt resource value: 0x7f06005d
 			public const int navigation_separator_vertical_padding = 2131099741;
@@ -2400,98 +2400,98 @@ namespace Xamarin.Forms.Player
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f050000
-			public const int ApplicationName = 2131034112;
-			
 			// aapt resource value: 0x7f05001e
-			public const int Hello = 2131034142;
-			
-			// aapt resource value: 0x7f05000b
-			public const int abc_action_bar_home_description = 2131034123;
-			
-			// aapt resource value: 0x7f050018
-			public const int abc_action_bar_home_description_format = 2131034136;
-			
-			// aapt resource value: 0x7f050019
-			public const int abc_action_bar_home_subtitle_description_format = 2131034137;
-			
-			// aapt resource value: 0x7f05000c
-			public const int abc_action_bar_up_description = 2131034124;
-			
-			// aapt resource value: 0x7f05000d
-			public const int abc_action_menu_overflow_description = 2131034125;
-			
-			// aapt resource value: 0x7f05000e
-			public const int abc_action_mode_done = 2131034126;
-			
-			// aapt resource value: 0x7f05000f
-			public const int abc_activity_chooser_view_see_all = 2131034127;
-			
-			// aapt resource value: 0x7f050010
-			public const int abc_activitychooserview_choose_application = 2131034128;
-			
-			// aapt resource value: 0x7f05001a
-			public const int abc_search_hint = 2131034138;
-			
-			// aapt resource value: 0x7f050011
-			public const int abc_searchview_description_clear = 2131034129;
-			
-			// aapt resource value: 0x7f050012
-			public const int abc_searchview_description_query = 2131034130;
-			
-			// aapt resource value: 0x7f050013
-			public const int abc_searchview_description_search = 2131034131;
-			
-			// aapt resource value: 0x7f050014
-			public const int abc_searchview_description_submit = 2131034132;
-			
-			// aapt resource value: 0x7f050015
-			public const int abc_searchview_description_voice = 2131034133;
-			
-			// aapt resource value: 0x7f050016
-			public const int abc_shareactionprovider_share_with = 2131034134;
-			
-			// aapt resource value: 0x7f050017
-			public const int abc_shareactionprovider_share_with_application = 2131034135;
-			
-			// aapt resource value: 0x7f05001b
-			public const int abc_toolbar_collapse_description = 2131034139;
+			public const int ApplicationName = 2131034142;
 			
 			// aapt resource value: 0x7f05001d
-			public const int appbar_scrolling_view_behavior = 2131034141;
-			
-			// aapt resource value: 0x7f050001
-			public const int mr_media_route_button_content_description = 2131034113;
-			
-			// aapt resource value: 0x7f050002
-			public const int mr_media_route_chooser_searching = 2131034114;
-			
-			// aapt resource value: 0x7f050003
-			public const int mr_media_route_chooser_title = 2131034115;
-			
-			// aapt resource value: 0x7f050004
-			public const int mr_media_route_controller_disconnect = 2131034116;
-			
-			// aapt resource value: 0x7f050007
-			public const int mr_media_route_controller_pause = 2131034119;
-			
-			// aapt resource value: 0x7f050008
-			public const int mr_media_route_controller_play = 2131034120;
-			
-			// aapt resource value: 0x7f050009
-			public const int mr_media_route_controller_settings_description = 2131034121;
+			public const int Hello = 2131034141;
 			
 			// aapt resource value: 0x7f05000a
-			public const int mr_media_route_controller_stop = 2131034122;
+			public const int abc_action_bar_home_description = 2131034122;
 			
-			// aapt resource value: 0x7f050005
-			public const int mr_system_route_name = 2131034117;
+			// aapt resource value: 0x7f050017
+			public const int abc_action_bar_home_description_format = 2131034135;
 			
-			// aapt resource value: 0x7f050006
-			public const int mr_user_route_category_name = 2131034118;
+			// aapt resource value: 0x7f050018
+			public const int abc_action_bar_home_subtitle_description_format = 2131034136;
+			
+			// aapt resource value: 0x7f05000b
+			public const int abc_action_bar_up_description = 2131034123;
+			
+			// aapt resource value: 0x7f05000c
+			public const int abc_action_menu_overflow_description = 2131034124;
+			
+			// aapt resource value: 0x7f05000d
+			public const int abc_action_mode_done = 2131034125;
+			
+			// aapt resource value: 0x7f05000e
+			public const int abc_activity_chooser_view_see_all = 2131034126;
+			
+			// aapt resource value: 0x7f05000f
+			public const int abc_activitychooserview_choose_application = 2131034127;
+			
+			// aapt resource value: 0x7f050019
+			public const int abc_search_hint = 2131034137;
+			
+			// aapt resource value: 0x7f050010
+			public const int abc_searchview_description_clear = 2131034128;
+			
+			// aapt resource value: 0x7f050011
+			public const int abc_searchview_description_query = 2131034129;
+			
+			// aapt resource value: 0x7f050012
+			public const int abc_searchview_description_search = 2131034130;
+			
+			// aapt resource value: 0x7f050013
+			public const int abc_searchview_description_submit = 2131034131;
+			
+			// aapt resource value: 0x7f050014
+			public const int abc_searchview_description_voice = 2131034132;
+			
+			// aapt resource value: 0x7f050015
+			public const int abc_shareactionprovider_share_with = 2131034133;
+			
+			// aapt resource value: 0x7f050016
+			public const int abc_shareactionprovider_share_with_application = 2131034134;
+			
+			// aapt resource value: 0x7f05001a
+			public const int abc_toolbar_collapse_description = 2131034138;
 			
 			// aapt resource value: 0x7f05001c
-			public const int status_bar_notification_info_overflow = 2131034140;
+			public const int appbar_scrolling_view_behavior = 2131034140;
+			
+			// aapt resource value: 0x7f050000
+			public const int mr_media_route_button_content_description = 2131034112;
+			
+			// aapt resource value: 0x7f050001
+			public const int mr_media_route_chooser_searching = 2131034113;
+			
+			// aapt resource value: 0x7f050002
+			public const int mr_media_route_chooser_title = 2131034114;
+			
+			// aapt resource value: 0x7f050003
+			public const int mr_media_route_controller_disconnect = 2131034115;
+			
+			// aapt resource value: 0x7f050006
+			public const int mr_media_route_controller_pause = 2131034118;
+			
+			// aapt resource value: 0x7f050007
+			public const int mr_media_route_controller_play = 2131034119;
+			
+			// aapt resource value: 0x7f050008
+			public const int mr_media_route_controller_settings_description = 2131034120;
+			
+			// aapt resource value: 0x7f050009
+			public const int mr_media_route_controller_stop = 2131034121;
+			
+			// aapt resource value: 0x7f050004
+			public const int mr_system_route_name = 2131034116;
+			
+			// aapt resource value: 0x7f050005
+			public const int mr_user_route_category_name = 2131034117;
+			
+			// aapt resource value: 0x7f05001b
+			public const int status_bar_notification_info_overflow = 2131034139;
 			
 			static String()
 			{
@@ -2506,218 +2506,218 @@ namespace Xamarin.Forms.Player
 		public partial class Style
 		{
 			
+			// aapt resource value: 0x7f07007a
+			public const int AlertDialog_AppCompat = 2131165306;
+			
+			// aapt resource value: 0x7f07007b
+			public const int AlertDialog_AppCompat_Light = 2131165307;
+			
+			// aapt resource value: 0x7f07007c
+			public const int Animation_AppCompat_Dialog = 2131165308;
+			
+			// aapt resource value: 0x7f07007d
+			public const int Animation_AppCompat_DropDownUp = 2131165309;
+			
+			// aapt resource value: 0x7f07007e
+			public const int Base_AlertDialog_AppCompat = 2131165310;
+			
+			// aapt resource value: 0x7f07007f
+			public const int Base_AlertDialog_AppCompat_Light = 2131165311;
+			
+			// aapt resource value: 0x7f070080
+			public const int Base_Animation_AppCompat_Dialog = 2131165312;
+			
+			// aapt resource value: 0x7f070081
+			public const int Base_Animation_AppCompat_DropDownUp = 2131165313;
+			
+			// aapt resource value: 0x7f070082
+			public const int Base_DialogWindowTitle_AppCompat = 2131165314;
+			
+			// aapt resource value: 0x7f070083
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131165315;
+			
 			// aapt resource value: 0x7f070035
-			public const int AlertDialog_AppCompat = 2131165237;
+			public const int Base_TextAppearance_AppCompat = 2131165237;
 			
 			// aapt resource value: 0x7f070036
-			public const int AlertDialog_AppCompat_Light = 2131165238;
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131165238;
 			
 			// aapt resource value: 0x7f070037
-			public const int Animation_AppCompat_Dialog = 2131165239;
-			
-			// aapt resource value: 0x7f070038
-			public const int Animation_AppCompat_DropDownUp = 2131165240;
-			
-			// aapt resource value: 0x7f070039
-			public const int Base_AlertDialog_AppCompat = 2131165241;
-			
-			// aapt resource value: 0x7f07003a
-			public const int Base_AlertDialog_AppCompat_Light = 2131165242;
-			
-			// aapt resource value: 0x7f07003b
-			public const int Base_Animation_AppCompat_Dialog = 2131165243;
-			
-			// aapt resource value: 0x7f07003c
-			public const int Base_Animation_AppCompat_DropDownUp = 2131165244;
-			
-			// aapt resource value: 0x7f07003d
-			public const int Base_DialogWindowTitle_AppCompat = 2131165245;
-			
-			// aapt resource value: 0x7f07003e
-			public const int Base_DialogWindowTitleBackground_AppCompat = 2131165246;
-			
-			// aapt resource value: 0x7f07003f
-			public const int Base_TextAppearance_AppCompat = 2131165247;
-			
-			// aapt resource value: 0x7f070040
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131165248;
-			
-			// aapt resource value: 0x7f070041
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131165249;
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131165239;
 			
 			// aapt resource value: 0x7f07001f
 			public const int Base_TextAppearance_AppCompat_Button = 2131165215;
 			
-			// aapt resource value: 0x7f070042
-			public const int Base_TextAppearance_AppCompat_Caption = 2131165250;
+			// aapt resource value: 0x7f070038
+			public const int Base_TextAppearance_AppCompat_Caption = 2131165240;
 			
-			// aapt resource value: 0x7f070043
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131165251;
+			// aapt resource value: 0x7f070039
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131165241;
 			
-			// aapt resource value: 0x7f070044
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131165252;
+			// aapt resource value: 0x7f07003a
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131165242;
 			
-			// aapt resource value: 0x7f070045
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131165253;
+			// aapt resource value: 0x7f07003b
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131165243;
 			
-			// aapt resource value: 0x7f070046
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131165254;
+			// aapt resource value: 0x7f07003c
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131165244;
 			
-			// aapt resource value: 0x7f070047
-			public const int Base_TextAppearance_AppCompat_Headline = 2131165255;
+			// aapt resource value: 0x7f07003d
+			public const int Base_TextAppearance_AppCompat_Headline = 2131165245;
 			
 			// aapt resource value: 0x7f07000a
 			public const int Base_TextAppearance_AppCompat_Inverse = 2131165194;
 			
-			// aapt resource value: 0x7f070048
-			public const int Base_TextAppearance_AppCompat_Large = 2131165256;
+			// aapt resource value: 0x7f07003e
+			public const int Base_TextAppearance_AppCompat_Large = 2131165246;
 			
 			// aapt resource value: 0x7f07000b
 			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131165195;
 			
-			// aapt resource value: 0x7f070049
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131165257;
+			// aapt resource value: 0x7f07003f
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131165247;
 			
-			// aapt resource value: 0x7f07004a
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131165258;
+			// aapt resource value: 0x7f070040
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131165248;
 			
-			// aapt resource value: 0x7f07004b
-			public const int Base_TextAppearance_AppCompat_Medium = 2131165259;
+			// aapt resource value: 0x7f070041
+			public const int Base_TextAppearance_AppCompat_Medium = 2131165249;
 			
 			// aapt resource value: 0x7f07000c
 			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131165196;
 			
-			// aapt resource value: 0x7f07004c
-			public const int Base_TextAppearance_AppCompat_Menu = 2131165260;
+			// aapt resource value: 0x7f070042
+			public const int Base_TextAppearance_AppCompat_Menu = 2131165250;
 			
-			// aapt resource value: 0x7f07004d
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131165261;
+			// aapt resource value: 0x7f070084
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131165316;
 			
-			// aapt resource value: 0x7f07004e
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131165262;
+			// aapt resource value: 0x7f070043
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131165251;
 			
-			// aapt resource value: 0x7f07004f
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131165263;
+			// aapt resource value: 0x7f070044
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131165252;
 			
-			// aapt resource value: 0x7f070050
-			public const int Base_TextAppearance_AppCompat_Small = 2131165264;
+			// aapt resource value: 0x7f070045
+			public const int Base_TextAppearance_AppCompat_Small = 2131165253;
 			
 			// aapt resource value: 0x7f07000d
 			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131165197;
 			
-			// aapt resource value: 0x7f070051
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131165265;
+			// aapt resource value: 0x7f070046
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131165254;
 			
 			// aapt resource value: 0x7f07000e
 			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131165198;
 			
-			// aapt resource value: 0x7f070052
-			public const int Base_TextAppearance_AppCompat_Title = 2131165266;
+			// aapt resource value: 0x7f070047
+			public const int Base_TextAppearance_AppCompat_Title = 2131165255;
 			
 			// aapt resource value: 0x7f07000f
 			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131165199;
 			
+			// aapt resource value: 0x7f070048
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131165256;
+			
+			// aapt resource value: 0x7f070049
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131165257;
+			
+			// aapt resource value: 0x7f07004a
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131165258;
+			
+			// aapt resource value: 0x7f07004b
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131165259;
+			
+			// aapt resource value: 0x7f07004c
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131165260;
+			
+			// aapt resource value: 0x7f07004d
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131165261;
+			
+			// aapt resource value: 0x7f07004e
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131165262;
+			
+			// aapt resource value: 0x7f070085
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131165317;
+			
+			// aapt resource value: 0x7f07004f
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131165263;
+			
+			// aapt resource value: 0x7f070050
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131165264;
+			
+			// aapt resource value: 0x7f070051
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131165265;
+			
+			// aapt resource value: 0x7f070052
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131165266;
+			
+			// aapt resource value: 0x7f070086
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131165318;
+			
 			// aapt resource value: 0x7f070053
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131165267;
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131165267;
 			
 			// aapt resource value: 0x7f070054
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131165268;
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131165268;
 			
 			// aapt resource value: 0x7f070055
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131165269;
+			public const int Base_Theme_AppCompat = 2131165269;
 			
-			// aapt resource value: 0x7f070056
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131165270;
-			
-			// aapt resource value: 0x7f070057
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131165271;
-			
-			// aapt resource value: 0x7f070058
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131165272;
-			
-			// aapt resource value: 0x7f070059
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131165273;
-			
-			// aapt resource value: 0x7f07005a
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131165274;
-			
-			// aapt resource value: 0x7f07005b
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131165275;
-			
-			// aapt resource value: 0x7f07005c
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131165276;
-			
-			// aapt resource value: 0x7f07005d
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131165277;
-			
-			// aapt resource value: 0x7f07005e
-			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131165278;
-			
-			// aapt resource value: 0x7f07005f
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131165279;
-			
-			// aapt resource value: 0x7f070060
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131165280;
-			
-			// aapt resource value: 0x7f070061
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131165281;
-			
-			// aapt resource value: 0x7f070062
-			public const int Base_Theme_AppCompat = 2131165282;
-			
-			// aapt resource value: 0x7f070063
-			public const int Base_Theme_AppCompat_CompactMenu = 2131165283;
+			// aapt resource value: 0x7f070087
+			public const int Base_Theme_AppCompat_CompactMenu = 2131165319;
 			
 			// aapt resource value: 0x7f070010
 			public const int Base_Theme_AppCompat_Dialog = 2131165200;
 			
-			// aapt resource value: 0x7f070064
-			public const int Base_Theme_AppCompat_Dialog_Alert = 2131165284;
+			// aapt resource value: 0x7f070088
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131165320;
 			
-			// aapt resource value: 0x7f070065
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131165285;
+			// aapt resource value: 0x7f070089
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131165321;
 			
-			// aapt resource value: 0x7f070066
-			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131165286;
+			// aapt resource value: 0x7f07008a
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131165322;
 			
 			// aapt resource value: 0x7f070008
 			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131165192;
 			
-			// aapt resource value: 0x7f070067
-			public const int Base_Theme_AppCompat_Light = 2131165287;
+			// aapt resource value: 0x7f070056
+			public const int Base_Theme_AppCompat_Light = 2131165270;
 			
-			// aapt resource value: 0x7f070068
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131165288;
+			// aapt resource value: 0x7f07008b
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131165323;
 			
 			// aapt resource value: 0x7f070011
 			public const int Base_Theme_AppCompat_Light_Dialog = 2131165201;
 			
-			// aapt resource value: 0x7f070069
-			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131165289;
+			// aapt resource value: 0x7f07008c
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131165324;
 			
-			// aapt resource value: 0x7f07006a
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131165290;
+			// aapt resource value: 0x7f07008d
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131165325;
 			
-			// aapt resource value: 0x7f07006b
-			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131165291;
+			// aapt resource value: 0x7f07008e
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131165326;
 			
 			// aapt resource value: 0x7f070009
 			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131165193;
 			
-			// aapt resource value: 0x7f07006c
-			public const int Base_ThemeOverlay_AppCompat = 2131165292;
+			// aapt resource value: 0x7f07008f
+			public const int Base_ThemeOverlay_AppCompat = 2131165327;
 			
-			// aapt resource value: 0x7f07006d
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131165293;
+			// aapt resource value: 0x7f070090
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131165328;
 			
-			// aapt resource value: 0x7f07006e
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131165294;
+			// aapt resource value: 0x7f070091
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131165329;
 			
-			// aapt resource value: 0x7f07006f
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131165295;
+			// aapt resource value: 0x7f070092
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131165330;
 			
-			// aapt resource value: 0x7f070070
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131165296;
+			// aapt resource value: 0x7f070093
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131165331;
 			
 			// aapt resource value: 0x7f070012
 			public const int Base_V11_Theme_AppCompat_Dialog = 2131165202;
@@ -2731,143 +2731,155 @@ namespace Xamarin.Forms.Player
 			// aapt resource value: 0x7f07001c
 			public const int Base_V12_Widget_AppCompat_EditText = 2131165212;
 			
-			// aapt resource value: 0x7f070071
-			public const int Base_V7_Theme_AppCompat = 2131165297;
+			// aapt resource value: 0x7f070057
+			public const int Base_V21_Theme_AppCompat = 2131165271;
 			
-			// aapt resource value: 0x7f070072
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131165298;
+			// aapt resource value: 0x7f070058
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131165272;
 			
-			// aapt resource value: 0x7f070073
-			public const int Base_V7_Theme_AppCompat_Light = 2131165299;
+			// aapt resource value: 0x7f070059
+			public const int Base_V21_Theme_AppCompat_Light = 2131165273;
 			
-			// aapt resource value: 0x7f070074
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131165300;
+			// aapt resource value: 0x7f07005a
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131165274;
 			
-			// aapt resource value: 0x7f070075
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131165301;
+			// aapt resource value: 0x7f070094
+			public const int Base_V7_Theme_AppCompat = 2131165332;
 			
-			// aapt resource value: 0x7f070076
-			public const int Base_V7_Widget_AppCompat_EditText = 2131165302;
+			// aapt resource value: 0x7f070095
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131165333;
 			
-			// aapt resource value: 0x7f070077
-			public const int Base_Widget_AppCompat_ActionBar = 2131165303;
+			// aapt resource value: 0x7f070096
+			public const int Base_V7_Theme_AppCompat_Light = 2131165334;
 			
-			// aapt resource value: 0x7f070078
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131165304;
+			// aapt resource value: 0x7f070097
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131165335;
 			
-			// aapt resource value: 0x7f070079
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131165305;
+			// aapt resource value: 0x7f070098
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131165336;
 			
-			// aapt resource value: 0x7f07007a
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131165306;
+			// aapt resource value: 0x7f070099
+			public const int Base_V7_Widget_AppCompat_EditText = 2131165337;
 			
-			// aapt resource value: 0x7f07007b
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131165307;
+			// aapt resource value: 0x7f07009a
+			public const int Base_Widget_AppCompat_ActionBar = 2131165338;
 			
-			// aapt resource value: 0x7f07007c
-			public const int Base_Widget_AppCompat_ActionButton = 2131165308;
+			// aapt resource value: 0x7f07009b
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131165339;
 			
-			// aapt resource value: 0x7f07007d
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131165309;
+			// aapt resource value: 0x7f07009c
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131165340;
 			
-			// aapt resource value: 0x7f07007e
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131165310;
+			// aapt resource value: 0x7f07005b
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131165275;
 			
-			// aapt resource value: 0x7f07007f
-			public const int Base_Widget_AppCompat_ActionMode = 2131165311;
+			// aapt resource value: 0x7f07005c
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131165276;
 			
-			// aapt resource value: 0x7f070080
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131165312;
+			// aapt resource value: 0x7f07005d
+			public const int Base_Widget_AppCompat_ActionButton = 2131165277;
+			
+			// aapt resource value: 0x7f07005e
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131165278;
+			
+			// aapt resource value: 0x7f07005f
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131165279;
+			
+			// aapt resource value: 0x7f07009d
+			public const int Base_Widget_AppCompat_ActionMode = 2131165341;
+			
+			// aapt resource value: 0x7f07009e
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131165342;
 			
 			// aapt resource value: 0x7f07001d
 			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131165213;
 			
-			// aapt resource value: 0x7f070081
-			public const int Base_Widget_AppCompat_Button = 2131165313;
+			// aapt resource value: 0x7f070060
+			public const int Base_Widget_AppCompat_Button = 2131165280;
 			
-			// aapt resource value: 0x7f070082
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131165314;
+			// aapt resource value: 0x7f070061
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131165281;
 			
-			// aapt resource value: 0x7f070083
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131165315;
+			// aapt resource value: 0x7f070062
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131165282;
 			
-			// aapt resource value: 0x7f070084
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131165316;
+			// aapt resource value: 0x7f07009f
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131165343;
 			
-			// aapt resource value: 0x7f070085
-			public const int Base_Widget_AppCompat_Button_Small = 2131165317;
+			// aapt resource value: 0x7f070063
+			public const int Base_Widget_AppCompat_Button_Small = 2131165283;
 			
-			// aapt resource value: 0x7f070086
-			public const int Base_Widget_AppCompat_ButtonBar = 2131165318;
+			// aapt resource value: 0x7f070064
+			public const int Base_Widget_AppCompat_ButtonBar = 2131165284;
 			
-			// aapt resource value: 0x7f070087
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131165319;
+			// aapt resource value: 0x7f0700a0
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131165344;
 			
-			// aapt resource value: 0x7f070088
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131165320;
+			// aapt resource value: 0x7f070065
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131165285;
 			
-			// aapt resource value: 0x7f070089
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131165321;
+			// aapt resource value: 0x7f070066
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131165286;
 			
-			// aapt resource value: 0x7f07008a
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131165322;
+			// aapt resource value: 0x7f0700a1
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131165345;
 			
 			// aapt resource value: 0x7f070007
 			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131165191;
 			
-			// aapt resource value: 0x7f07008b
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131165323;
+			// aapt resource value: 0x7f0700a2
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131165346;
 			
-			// aapt resource value: 0x7f07008c
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131165324;
+			// aapt resource value: 0x7f070067
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131165287;
 			
 			// aapt resource value: 0x7f07001e
 			public const int Base_Widget_AppCompat_EditText = 2131165214;
 			
-			// aapt resource value: 0x7f07008d
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131165325;
+			// aapt resource value: 0x7f0700a3
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131165347;
 			
-			// aapt resource value: 0x7f07008e
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131165326;
+			// aapt resource value: 0x7f0700a4
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131165348;
 			
-			// aapt resource value: 0x7f07008f
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131165327;
+			// aapt resource value: 0x7f0700a5
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131165349;
 			
-			// aapt resource value: 0x7f070090
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131165328;
+			// aapt resource value: 0x7f070068
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131165288;
 			
-			// aapt resource value: 0x7f070091
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131165329;
+			// aapt resource value: 0x7f070069
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131165289;
 			
-			// aapt resource value: 0x7f070092
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131165330;
+			// aapt resource value: 0x7f07006a
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131165290;
 			
-			// aapt resource value: 0x7f070093
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131165331;
+			// aapt resource value: 0x7f07006b
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131165291;
 			
-			// aapt resource value: 0x7f070094
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131165332;
+			// aapt resource value: 0x7f07006c
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131165292;
 			
-			// aapt resource value: 0x7f070095
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131165333;
+			// aapt resource value: 0x7f07006d
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131165293;
 			
-			// aapt resource value: 0x7f070096
-			public const int Base_Widget_AppCompat_ListView = 2131165334;
+			// aapt resource value: 0x7f07006e
+			public const int Base_Widget_AppCompat_ListView = 2131165294;
 			
-			// aapt resource value: 0x7f070097
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131165335;
+			// aapt resource value: 0x7f07006f
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131165295;
 			
-			// aapt resource value: 0x7f070098
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131165336;
+			// aapt resource value: 0x7f070070
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131165296;
 			
-			// aapt resource value: 0x7f070099
-			public const int Base_Widget_AppCompat_PopupMenu = 2131165337;
+			// aapt resource value: 0x7f070071
+			public const int Base_Widget_AppCompat_PopupMenu = 2131165297;
 			
-			// aapt resource value: 0x7f07009a
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131165338;
+			// aapt resource value: 0x7f070072
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131165298;
 			
-			// aapt resource value: 0x7f07009b
-			public const int Base_Widget_AppCompat_PopupWindow = 2131165339;
+			// aapt resource value: 0x7f0700a6
+			public const int Base_Widget_AppCompat_PopupWindow = 2131165350;
 			
 			// aapt resource value: 0x7f070014
 			public const int Base_Widget_AppCompat_ProgressBar = 2131165204;
@@ -2875,35 +2887,35 @@ namespace Xamarin.Forms.Player
 			// aapt resource value: 0x7f070015
 			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131165205;
 			
-			// aapt resource value: 0x7f07009c
-			public const int Base_Widget_AppCompat_RatingBar = 2131165340;
+			// aapt resource value: 0x7f070073
+			public const int Base_Widget_AppCompat_RatingBar = 2131165299;
 			
-			// aapt resource value: 0x7f07009d
-			public const int Base_Widget_AppCompat_SearchView = 2131165341;
+			// aapt resource value: 0x7f0700a7
+			public const int Base_Widget_AppCompat_SearchView = 2131165351;
 			
-			// aapt resource value: 0x7f07009e
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131165342;
+			// aapt resource value: 0x7f0700a8
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131165352;
 			
 			// aapt resource value: 0x7f070016
 			public const int Base_Widget_AppCompat_Spinner = 2131165206;
 			
-			// aapt resource value: 0x7f07009f
-			public const int Base_Widget_AppCompat_Spinner_DropDown_ActionBar = 2131165343;
+			// aapt resource value: 0x7f070074
+			public const int Base_Widget_AppCompat_Spinner_DropDown_ActionBar = 2131165300;
 			
-			// aapt resource value: 0x7f0700a0
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131165344;
+			// aapt resource value: 0x7f070075
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131165301;
 			
-			// aapt resource value: 0x7f0700a1
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131165345;
+			// aapt resource value: 0x7f070076
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131165302;
 			
-			// aapt resource value: 0x7f0700a2
-			public const int Base_Widget_AppCompat_Toolbar = 2131165346;
+			// aapt resource value: 0x7f0700a9
+			public const int Base_Widget_AppCompat_Toolbar = 2131165353;
 			
-			// aapt resource value: 0x7f0700a3
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131165347;
+			// aapt resource value: 0x7f070077
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131165303;
 			
-			// aapt resource value: 0x7f070128
-			public const int Base_Widget_Design_TabLayout = 2131165480;
+			// aapt resource value: 0x7f07012c
+			public const int Base_Widget_Design_TabLayout = 2131165484;
 			
 			// aapt resource value: 0x7f070004
 			public const int CardView = 2131165188;
@@ -2920,11 +2932,11 @@ namespace Xamarin.Forms.Player
 			// aapt resource value: 0x7f070018
 			public const int Platform_AppCompat_Light = 2131165208;
 			
-			// aapt resource value: 0x7f0700a4
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131165348;
+			// aapt resource value: 0x7f070078
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131165304;
 			
-			// aapt resource value: 0x7f0700a5
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131165349;
+			// aapt resource value: 0x7f070079
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131165305;
 			
 			// aapt resource value: 0x7f070019
 			public const int Platform_V11_AppCompat = 2131165209;
@@ -2980,149 +2992,149 @@ namespace Xamarin.Forms.Player
 			// aapt resource value: 0x7f070034
 			public const int RtlOverlay_Widget_AppCompat_Toolbar_Button_Navigation = 2131165236;
 			
-			// aapt resource value: 0x7f0700a6
-			public const int TextAppearance_AppCompat = 2131165350;
-			
-			// aapt resource value: 0x7f0700a7
-			public const int TextAppearance_AppCompat_Body1 = 2131165351;
-			
-			// aapt resource value: 0x7f0700a8
-			public const int TextAppearance_AppCompat_Body2 = 2131165352;
-			
-			// aapt resource value: 0x7f0700a9
-			public const int TextAppearance_AppCompat_Button = 2131165353;
-			
 			// aapt resource value: 0x7f0700aa
-			public const int TextAppearance_AppCompat_Caption = 2131165354;
+			public const int TextAppearance_AppCompat = 2131165354;
 			
 			// aapt resource value: 0x7f0700ab
-			public const int TextAppearance_AppCompat_Display1 = 2131165355;
+			public const int TextAppearance_AppCompat_Body1 = 2131165355;
 			
 			// aapt resource value: 0x7f0700ac
-			public const int TextAppearance_AppCompat_Display2 = 2131165356;
+			public const int TextAppearance_AppCompat_Body2 = 2131165356;
 			
 			// aapt resource value: 0x7f0700ad
-			public const int TextAppearance_AppCompat_Display3 = 2131165357;
+			public const int TextAppearance_AppCompat_Button = 2131165357;
 			
 			// aapt resource value: 0x7f0700ae
-			public const int TextAppearance_AppCompat_Display4 = 2131165358;
+			public const int TextAppearance_AppCompat_Caption = 2131165358;
 			
 			// aapt resource value: 0x7f0700af
-			public const int TextAppearance_AppCompat_Headline = 2131165359;
+			public const int TextAppearance_AppCompat_Display1 = 2131165359;
 			
 			// aapt resource value: 0x7f0700b0
-			public const int TextAppearance_AppCompat_Inverse = 2131165360;
+			public const int TextAppearance_AppCompat_Display2 = 2131165360;
 			
 			// aapt resource value: 0x7f0700b1
-			public const int TextAppearance_AppCompat_Large = 2131165361;
+			public const int TextAppearance_AppCompat_Display3 = 2131165361;
 			
 			// aapt resource value: 0x7f0700b2
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131165362;
+			public const int TextAppearance_AppCompat_Display4 = 2131165362;
 			
 			// aapt resource value: 0x7f0700b3
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131165363;
+			public const int TextAppearance_AppCompat_Headline = 2131165363;
 			
 			// aapt resource value: 0x7f0700b4
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131165364;
+			public const int TextAppearance_AppCompat_Inverse = 2131165364;
 			
 			// aapt resource value: 0x7f0700b5
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131165365;
+			public const int TextAppearance_AppCompat_Large = 2131165365;
 			
 			// aapt resource value: 0x7f0700b6
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131165366;
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131165366;
 			
 			// aapt resource value: 0x7f0700b7
-			public const int TextAppearance_AppCompat_Medium = 2131165367;
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131165367;
 			
 			// aapt resource value: 0x7f0700b8
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131165368;
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131165368;
 			
 			// aapt resource value: 0x7f0700b9
-			public const int TextAppearance_AppCompat_Menu = 2131165369;
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131165369;
 			
 			// aapt resource value: 0x7f0700ba
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131165370;
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131165370;
 			
 			// aapt resource value: 0x7f0700bb
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131165371;
+			public const int TextAppearance_AppCompat_Medium = 2131165371;
 			
 			// aapt resource value: 0x7f0700bc
-			public const int TextAppearance_AppCompat_Small = 2131165372;
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131165372;
 			
 			// aapt resource value: 0x7f0700bd
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131165373;
+			public const int TextAppearance_AppCompat_Menu = 2131165373;
 			
 			// aapt resource value: 0x7f0700be
-			public const int TextAppearance_AppCompat_Subhead = 2131165374;
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131165374;
 			
 			// aapt resource value: 0x7f0700bf
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131165375;
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131165375;
 			
 			// aapt resource value: 0x7f0700c0
-			public const int TextAppearance_AppCompat_Title = 2131165376;
+			public const int TextAppearance_AppCompat_Small = 2131165376;
 			
 			// aapt resource value: 0x7f0700c1
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131165377;
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131165377;
 			
 			// aapt resource value: 0x7f0700c2
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131165378;
+			public const int TextAppearance_AppCompat_Subhead = 2131165378;
 			
 			// aapt resource value: 0x7f0700c3
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131165379;
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131165379;
 			
 			// aapt resource value: 0x7f0700c4
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131165380;
+			public const int TextAppearance_AppCompat_Title = 2131165380;
 			
 			// aapt resource value: 0x7f0700c5
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131165381;
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131165381;
 			
 			// aapt resource value: 0x7f0700c6
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131165382;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131165382;
 			
 			// aapt resource value: 0x7f0700c7
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131165383;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131165383;
 			
 			// aapt resource value: 0x7f0700c8
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131165384;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131165384;
 			
 			// aapt resource value: 0x7f0700c9
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131165385;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131165385;
 			
 			// aapt resource value: 0x7f0700ca
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131165386;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131165386;
 			
 			// aapt resource value: 0x7f0700cb
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131165387;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131165387;
 			
 			// aapt resource value: 0x7f0700cc
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131165388;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131165388;
 			
 			// aapt resource value: 0x7f0700cd
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131165389;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131165389;
 			
 			// aapt resource value: 0x7f0700ce
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131165390;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131165390;
 			
 			// aapt resource value: 0x7f0700cf
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131165391;
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131165391;
 			
-			// aapt resource value: 0x7f070129
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131165481;
+			// aapt resource value: 0x7f0700d0
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131165392;
 			
-			// aapt resource value: 0x7f07012a
-			public const int TextAppearance_Design_Error = 2131165482;
+			// aapt resource value: 0x7f0700d1
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131165393;
 			
-			// aapt resource value: 0x7f07012b
-			public const int TextAppearance_Design_Hint = 2131165483;
+			// aapt resource value: 0x7f0700d2
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131165394;
 			
-			// aapt resource value: 0x7f07012c
-			public const int TextAppearance_Design_Snackbar_Action = 2131165484;
+			// aapt resource value: 0x7f0700d3
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131165395;
 			
 			// aapt resource value: 0x7f07012d
-			public const int TextAppearance_Design_Snackbar_Message = 2131165485;
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131165485;
 			
 			// aapt resource value: 0x7f07012e
-			public const int TextAppearance_Design_Tab = 2131165486;
+			public const int TextAppearance_Design_Error = 2131165486;
+			
+			// aapt resource value: 0x7f07012f
+			public const int TextAppearance_Design_Hint = 2131165487;
+			
+			// aapt resource value: 0x7f070130
+			public const int TextAppearance_Design_Snackbar_Action = 2131165488;
+			
+			// aapt resource value: 0x7f070131
+			public const int TextAppearance_Design_Snackbar_Message = 2131165489;
+			
+			// aapt resource value: 0x7f070132
+			public const int TextAppearance_Design_Tab = 2131165490;
 			
 			// aapt resource value: 0x7f070022
 			public const int TextAppearance_StatusBar_EventContent = 2131165218;
@@ -3139,56 +3151,56 @@ namespace Xamarin.Forms.Player
 			// aapt resource value: 0x7f070026
 			public const int TextAppearance_StatusBar_EventContent_Title = 2131165222;
 			
-			// aapt resource value: 0x7f0700d0
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131165392;
-			
-			// aapt resource value: 0x7f0700d1
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131165393;
-			
-			// aapt resource value: 0x7f0700d2
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131165394;
-			
-			// aapt resource value: 0x7f0700d3
-			public const int Theme_AppCompat = 2131165395;
-			
 			// aapt resource value: 0x7f0700d4
-			public const int Theme_AppCompat_CompactMenu = 2131165396;
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131165396;
 			
 			// aapt resource value: 0x7f0700d5
-			public const int Theme_AppCompat_Dialog = 2131165397;
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131165397;
 			
 			// aapt resource value: 0x7f0700d6
-			public const int Theme_AppCompat_Dialog_Alert = 2131165398;
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131165398;
 			
 			// aapt resource value: 0x7f0700d7
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131165399;
+			public const int Theme_AppCompat = 2131165399;
 			
 			// aapt resource value: 0x7f0700d8
-			public const int Theme_AppCompat_DialogWhenLarge = 2131165400;
+			public const int Theme_AppCompat_CompactMenu = 2131165400;
 			
 			// aapt resource value: 0x7f0700d9
-			public const int Theme_AppCompat_Light = 2131165401;
+			public const int Theme_AppCompat_Dialog = 2131165401;
 			
 			// aapt resource value: 0x7f0700da
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131165402;
+			public const int Theme_AppCompat_Dialog_Alert = 2131165402;
 			
 			// aapt resource value: 0x7f0700db
-			public const int Theme_AppCompat_Light_Dialog = 2131165403;
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131165403;
 			
 			// aapt resource value: 0x7f0700dc
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131165404;
+			public const int Theme_AppCompat_DialogWhenLarge = 2131165404;
 			
 			// aapt resource value: 0x7f0700dd
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131165405;
+			public const int Theme_AppCompat_Light = 2131165405;
 			
 			// aapt resource value: 0x7f0700de
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131165406;
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131165406;
 			
 			// aapt resource value: 0x7f0700df
-			public const int Theme_AppCompat_Light_NoActionBar = 2131165407;
+			public const int Theme_AppCompat_Light_Dialog = 2131165407;
 			
 			// aapt resource value: 0x7f0700e0
-			public const int Theme_AppCompat_NoActionBar = 2131165408;
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131165408;
+			
+			// aapt resource value: 0x7f0700e1
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131165409;
+			
+			// aapt resource value: 0x7f0700e2
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131165410;
+			
+			// aapt resource value: 0x7f0700e3
+			public const int Theme_AppCompat_Light_NoActionBar = 2131165411;
+			
+			// aapt resource value: 0x7f0700e4
+			public const int Theme_AppCompat_NoActionBar = 2131165412;
 			
 			// aapt resource value: 0x7f070000
 			public const int Theme_MediaRouter = 2131165184;
@@ -3196,242 +3208,242 @@ namespace Xamarin.Forms.Player
 			// aapt resource value: 0x7f070001
 			public const int Theme_MediaRouter_Light = 2131165185;
 			
-			// aapt resource value: 0x7f0700e1
-			public const int ThemeOverlay_AppCompat = 2131165409;
-			
-			// aapt resource value: 0x7f0700e2
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131165410;
-			
-			// aapt resource value: 0x7f0700e3
-			public const int ThemeOverlay_AppCompat_Dark = 2131165411;
-			
-			// aapt resource value: 0x7f0700e4
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131165412;
-			
 			// aapt resource value: 0x7f0700e5
-			public const int ThemeOverlay_AppCompat_Light = 2131165413;
+			public const int ThemeOverlay_AppCompat = 2131165413;
 			
 			// aapt resource value: 0x7f0700e6
-			public const int Widget_AppCompat_ActionBar = 2131165414;
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131165414;
 			
 			// aapt resource value: 0x7f0700e7
-			public const int Widget_AppCompat_ActionBar_Solid = 2131165415;
+			public const int ThemeOverlay_AppCompat_Dark = 2131165415;
 			
 			// aapt resource value: 0x7f0700e8
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131165416;
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131165416;
 			
 			// aapt resource value: 0x7f0700e9
-			public const int Widget_AppCompat_ActionBar_TabText = 2131165417;
+			public const int ThemeOverlay_AppCompat_Light = 2131165417;
 			
 			// aapt resource value: 0x7f0700ea
-			public const int Widget_AppCompat_ActionBar_TabView = 2131165418;
+			public const int Widget_AppCompat_ActionBar = 2131165418;
 			
 			// aapt resource value: 0x7f0700eb
-			public const int Widget_AppCompat_ActionButton = 2131165419;
+			public const int Widget_AppCompat_ActionBar_Solid = 2131165419;
 			
 			// aapt resource value: 0x7f0700ec
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131165420;
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131165420;
 			
 			// aapt resource value: 0x7f0700ed
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131165421;
+			public const int Widget_AppCompat_ActionBar_TabText = 2131165421;
 			
 			// aapt resource value: 0x7f0700ee
-			public const int Widget_AppCompat_ActionMode = 2131165422;
+			public const int Widget_AppCompat_ActionBar_TabView = 2131165422;
 			
 			// aapt resource value: 0x7f0700ef
-			public const int Widget_AppCompat_ActivityChooserView = 2131165423;
+			public const int Widget_AppCompat_ActionButton = 2131165423;
 			
 			// aapt resource value: 0x7f0700f0
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131165424;
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131165424;
 			
 			// aapt resource value: 0x7f0700f1
-			public const int Widget_AppCompat_Button = 2131165425;
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131165425;
 			
 			// aapt resource value: 0x7f0700f2
-			public const int Widget_AppCompat_Button_Borderless = 2131165426;
+			public const int Widget_AppCompat_ActionMode = 2131165426;
 			
 			// aapt resource value: 0x7f0700f3
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131165427;
+			public const int Widget_AppCompat_ActivityChooserView = 2131165427;
 			
 			// aapt resource value: 0x7f0700f4
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131165428;
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131165428;
 			
 			// aapt resource value: 0x7f0700f5
-			public const int Widget_AppCompat_Button_Small = 2131165429;
+			public const int Widget_AppCompat_Button = 2131165429;
 			
 			// aapt resource value: 0x7f0700f6
-			public const int Widget_AppCompat_ButtonBar = 2131165430;
+			public const int Widget_AppCompat_Button_Borderless = 2131165430;
 			
 			// aapt resource value: 0x7f0700f7
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131165431;
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131165431;
 			
 			// aapt resource value: 0x7f0700f8
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131165432;
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131165432;
 			
 			// aapt resource value: 0x7f0700f9
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131165433;
+			public const int Widget_AppCompat_Button_Small = 2131165433;
 			
 			// aapt resource value: 0x7f0700fa
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131165434;
+			public const int Widget_AppCompat_ButtonBar = 2131165434;
 			
 			// aapt resource value: 0x7f0700fb
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131165435;
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131165435;
 			
 			// aapt resource value: 0x7f0700fc
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131165436;
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131165436;
 			
 			// aapt resource value: 0x7f0700fd
-			public const int Widget_AppCompat_EditText = 2131165437;
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131165437;
 			
 			// aapt resource value: 0x7f0700fe
-			public const int Widget_AppCompat_Light_ActionBar = 2131165438;
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131165438;
 			
 			// aapt resource value: 0x7f0700ff
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131165439;
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131165439;
 			
 			// aapt resource value: 0x7f070100
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131165440;
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131165440;
 			
 			// aapt resource value: 0x7f070101
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131165441;
+			public const int Widget_AppCompat_EditText = 2131165441;
 			
 			// aapt resource value: 0x7f070102
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131165442;
+			public const int Widget_AppCompat_Light_ActionBar = 2131165442;
 			
 			// aapt resource value: 0x7f070103
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131165443;
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131165443;
 			
 			// aapt resource value: 0x7f070104
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131165444;
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131165444;
 			
 			// aapt resource value: 0x7f070105
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131165445;
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131165445;
 			
 			// aapt resource value: 0x7f070106
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131165446;
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131165446;
 			
 			// aapt resource value: 0x7f070107
-			public const int Widget_AppCompat_Light_ActionButton = 2131165447;
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131165447;
 			
 			// aapt resource value: 0x7f070108
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131165448;
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131165448;
 			
 			// aapt resource value: 0x7f070109
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131165449;
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131165449;
 			
 			// aapt resource value: 0x7f07010a
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131165450;
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131165450;
 			
 			// aapt resource value: 0x7f07010b
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131165451;
+			public const int Widget_AppCompat_Light_ActionButton = 2131165451;
 			
 			// aapt resource value: 0x7f07010c
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131165452;
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131165452;
 			
 			// aapt resource value: 0x7f07010d
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131165453;
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131165453;
 			
 			// aapt resource value: 0x7f07010e
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131165454;
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131165454;
 			
 			// aapt resource value: 0x7f07010f
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131165455;
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131165455;
 			
 			// aapt resource value: 0x7f070110
-			public const int Widget_AppCompat_Light_PopupMenu = 2131165456;
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131165456;
 			
 			// aapt resource value: 0x7f070111
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131165457;
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131165457;
 			
 			// aapt resource value: 0x7f070112
-			public const int Widget_AppCompat_Light_SearchView = 2131165458;
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131165458;
 			
 			// aapt resource value: 0x7f070113
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131165459;
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131165459;
 			
 			// aapt resource value: 0x7f070114
-			public const int Widget_AppCompat_ListPopupWindow = 2131165460;
+			public const int Widget_AppCompat_Light_PopupMenu = 2131165460;
 			
 			// aapt resource value: 0x7f070115
-			public const int Widget_AppCompat_ListView = 2131165461;
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131165461;
 			
 			// aapt resource value: 0x7f070116
-			public const int Widget_AppCompat_ListView_DropDown = 2131165462;
+			public const int Widget_AppCompat_Light_SearchView = 2131165462;
 			
 			// aapt resource value: 0x7f070117
-			public const int Widget_AppCompat_ListView_Menu = 2131165463;
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131165463;
 			
 			// aapt resource value: 0x7f070118
-			public const int Widget_AppCompat_PopupMenu = 2131165464;
+			public const int Widget_AppCompat_ListPopupWindow = 2131165464;
 			
 			// aapt resource value: 0x7f070119
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131165465;
+			public const int Widget_AppCompat_ListView = 2131165465;
 			
 			// aapt resource value: 0x7f07011a
-			public const int Widget_AppCompat_PopupWindow = 2131165466;
+			public const int Widget_AppCompat_ListView_DropDown = 2131165466;
 			
 			// aapt resource value: 0x7f07011b
-			public const int Widget_AppCompat_ProgressBar = 2131165467;
+			public const int Widget_AppCompat_ListView_Menu = 2131165467;
 			
 			// aapt resource value: 0x7f07011c
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131165468;
+			public const int Widget_AppCompat_PopupMenu = 2131165468;
 			
 			// aapt resource value: 0x7f07011d
-			public const int Widget_AppCompat_RatingBar = 2131165469;
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131165469;
 			
 			// aapt resource value: 0x7f07011e
-			public const int Widget_AppCompat_SearchView = 2131165470;
+			public const int Widget_AppCompat_PopupWindow = 2131165470;
 			
 			// aapt resource value: 0x7f07011f
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131165471;
+			public const int Widget_AppCompat_ProgressBar = 2131165471;
 			
 			// aapt resource value: 0x7f070120
-			public const int Widget_AppCompat_Spinner = 2131165472;
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131165472;
 			
 			// aapt resource value: 0x7f070121
-			public const int Widget_AppCompat_Spinner_DropDown = 2131165473;
+			public const int Widget_AppCompat_RatingBar = 2131165473;
 			
 			// aapt resource value: 0x7f070122
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131165474;
+			public const int Widget_AppCompat_SearchView = 2131165474;
 			
 			// aapt resource value: 0x7f070123
-			public const int Widget_AppCompat_Spinner_Underlined = 2131165475;
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131165475;
 			
 			// aapt resource value: 0x7f070124
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131165476;
+			public const int Widget_AppCompat_Spinner = 2131165476;
 			
 			// aapt resource value: 0x7f070125
-			public const int Widget_AppCompat_Toolbar = 2131165477;
+			public const int Widget_AppCompat_Spinner_DropDown = 2131165477;
 			
 			// aapt resource value: 0x7f070126
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131165478;
-			
-			// aapt resource value: 0x7f07012f
-			public const int Widget_Design_AppBarLayout = 2131165487;
-			
-			// aapt resource value: 0x7f070130
-			public const int Widget_Design_CollapsingToolbar = 2131165488;
-			
-			// aapt resource value: 0x7f070131
-			public const int Widget_Design_CoordinatorLayout = 2131165489;
-			
-			// aapt resource value: 0x7f070132
-			public const int Widget_Design_FloatingActionButton = 2131165490;
-			
-			// aapt resource value: 0x7f070133
-			public const int Widget_Design_NavigationView = 2131165491;
-			
-			// aapt resource value: 0x7f070134
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131165492;
-			
-			// aapt resource value: 0x7f070135
-			public const int Widget_Design_Snackbar = 2131165493;
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131165478;
 			
 			// aapt resource value: 0x7f070127
-			public const int Widget_Design_TabLayout = 2131165479;
+			public const int Widget_AppCompat_Spinner_Underlined = 2131165479;
+			
+			// aapt resource value: 0x7f070128
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131165480;
+			
+			// aapt resource value: 0x7f070129
+			public const int Widget_AppCompat_Toolbar = 2131165481;
+			
+			// aapt resource value: 0x7f07012a
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131165482;
+			
+			// aapt resource value: 0x7f070133
+			public const int Widget_Design_AppBarLayout = 2131165491;
+			
+			// aapt resource value: 0x7f070134
+			public const int Widget_Design_CollapsingToolbar = 2131165492;
+			
+			// aapt resource value: 0x7f070135
+			public const int Widget_Design_CoordinatorLayout = 2131165493;
 			
 			// aapt resource value: 0x7f070136
-			public const int Widget_Design_TextInputLayout = 2131165494;
+			public const int Widget_Design_FloatingActionButton = 2131165494;
+			
+			// aapt resource value: 0x7f070137
+			public const int Widget_Design_NavigationView = 2131165495;
+			
+			// aapt resource value: 0x7f070138
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131165496;
+			
+			// aapt resource value: 0x7f070139
+			public const int Widget_Design_Snackbar = 2131165497;
+			
+			// aapt resource value: 0x7f07012b
+			public const int Widget_Design_TabLayout = 2131165483;
+			
+			// aapt resource value: 0x7f07013a
+			public const int Widget_Design_TextInputLayout = 2131165498;
 			
 			// aapt resource value: 0x7f070002
 			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131165186;

--- a/src/FormsPlayer.Android/packages.config
+++ b/src/FormsPlayer.Android/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="monoandroid41" userInstalled="true" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="monoandroid41" userInstalled="true" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="monoandroid23" userInstalled="true" />
-  <package id="Xam.Plugins.Settings" version="1.5.2" targetFramework="monoandroid41" userInstalled="true" />
+  <package id="Xam.Plugins.Settings" version="2.1.0" targetFramework="monoandroid44" userInstalled="true" />
   <package id="Xamarin.Android.Support.Design" version="22.2.1.0" targetFramework="monoandroid41" />
   <package id="Xamarin.Android.Support.v4" version="22.2.1.0" targetFramework="monoandroid41" userInstalled="true" />
   <package id="Xamarin.Android.Support.v7.AppCompat" version="22.2.1.0" targetFramework="monoandroid41" />

--- a/src/FormsPlayer.iOS/FormsPlayer.iOS.csproj
+++ b/src/FormsPlayer.iOS/FormsPlayer.iOS.csproj
@@ -98,12 +98,12 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Refractored.Xam.Settings, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xam.Plugins.Settings.1.5.2\lib\Xamarin.iOS10\Refractored.Xam.Settings.dll</HintPath>
+    <Reference Include="Plugin.Settings, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xam.Plugins.Settings.2.1.0\lib\Xamarin.iOS10\Plugin.Settings.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Refractored.Xam.Settings.Abstractions, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xam.Plugins.Settings.1.5.2\lib\Xamarin.iOS10\Refractored.Xam.Settings.Abstractions.dll</HintPath>
+    <Reference Include="Plugin.Settings.Abstractions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xam.Plugins.Settings.2.1.0\lib\Xamarin.iOS10\Plugin.Settings.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -201,12 +201,14 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AppDelegate.cs" />
+    <Compile Include="Helpers\Settings.cs" />
     <Compile Include="Main.cs" />
     <Content Include="Info.plist" />
     <Content Include="Entitlements.plist" />
-    <Content Include="PluginsHelp\SettingsReadme.txt" />
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/FormsPlayer.iOS/Helpers/Settings.cs
+++ b/src/FormsPlayer.iOS/Helpers/Settings.cs
@@ -1,11 +1,7 @@
-Ensure that you install NuGet into PCL and see Helpers/Settings.cs
-
-If you are installing this in a normal project and not using a pcl create a new file called Settings.cs or whatever you want and copy this code in:
-
-
-// Helpers/Settings.cs
-using Refractored.Xam.Settings;
-using Refractored.Xam.Settings.Abstractions;
+/*
+// Helpers/Settings.cs This file was automatically added when you installed the Settings Plugin. If you are not using a PCL then comment this file back in to use it.
+using Plugin.Settings;
+using Plugin.Settings.Abstractions;
 
 namespace Xamarin.Forms.Player.Helpers
 {
@@ -45,4 +41,4 @@ namespace Xamarin.Forms.Player.Helpers
     }
 
   }
-}
+}*/

--- a/src/FormsPlayer.iOS/packages.config
+++ b/src/FormsPlayer.iOS/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="xamarinios1" userInstalled="true" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="xamarinios1" userInstalled="true" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="xamarinios1" userInstalled="true" />
-  <package id="Xam.Plugins.Settings" version="1.5.2" targetFramework="xamarinios1" userInstalled="true" />
+  <package id="Xam.Plugins.Settings" version="2.1.0" targetFramework="xamarinios10" userInstalled="true" />
   <package id="Xamarin.Forms" version="1.5.0.6447" targetFramework="xamarinios1" />
   <package id="Xamarin.Forms.Dynamic" version="0.1.17-pre" targetFramework="xamarinios1" />
 </packages>

--- a/src/FormsPlayer.sln
+++ b/src/FormsPlayer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23103.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PublishScripts", "PublishScripts", "{6B88C8F4-22F2-43AE-B3C8-85C83DE31CC8}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/FormsPlayer/App.cs
+++ b/src/FormsPlayer/App.cs
@@ -13,14 +13,14 @@ namespace Xamarin.Forms.Player
 	/// </summary>
 	public class App : Application
 	{
-	    private AppController _controller;
+	    AppController controller;
 
 	    /// <summary>
 		/// Initializes the application.
 		/// </summary>
 		public App ()
 		{
-            _controller = new AppController(this);
+            controller = new AppController(this);
 		}
         
 		/// <summary>
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Player
 		/// </summary>
 		protected override void OnStart ()
 		{
-			_controller.OnStart();
+			controller.OnStart();
 		}
 
 		/// <summary>
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Player
 		/// </summary>
 		protected override void OnSleep ()
 		{
-			_controller.OnSleep();
+			controller.OnSleep();
 		}
 
 		/// <summary>
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Player
 		/// </summary>
 		protected override void OnResume ()
 		{
-			_controller.OnResume();
+			controller.OnResume();
 		}
 	}
 }

--- a/src/FormsPlayer/App.cs
+++ b/src/FormsPlayer/App.cs
@@ -13,147 +13,22 @@ namespace Xamarin.Forms.Player
 	/// </summary>
 	public class App : Application
 	{
-		static readonly string FormsAssemblyName = typeof (ContentPage).AssemblyQualifiedName.Substring(typeof (ContentPage).AssemblyQualifiedName.IndexOf(',') + 1).Trim();
+	    private AppController _controller;
 
-		AppViewModel viewModel;
-
-		/// <summary>
+	    /// <summary>
 		/// Initializes the application.
 		/// </summary>
 		public App ()
 		{
-			viewModel = new AppViewModel ();
-			viewModel.PropertyChanged += OnPropertyChanged;
-
-			SetPage(new MainView { BindingContext = viewModel });
+            _controller = new AppController(this);
 		}
-
-		void OnPropertyChanged (object sender, PropertyChangedEventArgs e)
-		{
-			// NOTE: we re-read both XAML and JSON because just re-applying 
-			// the JSON to the BindingContext didn't work reliably.
-			if (e.PropertyName == "Xaml" || e.PropertyName == "Json") {
-				Device.BeginInvokeOnMainThread (() => {
-					try {
-						// Reload view from XAML and model from JSON. 
-						// Ensures we always refresh both.
-						var content = MainPage;
-
-						// We first try to read the root element name from the XAML
-						if (!string.IsNullOrEmpty (viewModel.Xaml))
-						{
-							using (var reader = XmlReader.Create (new StringReader (viewModel.Xaml))) 
-							{
-								if (reader.MoveToContent() == XmlNodeType.Element)
-								{
-									var rootElement = reader.Name;
-
-									// If it contains a colon, then it is not derived from the Xamarin.Forms namespace
-									if (rootElement.Contains(":"))
-									{
-										// Extract the Namespace, class and assembly info
-										var classInfo = reader.NamespaceURI;
-
-										var colonIndex = classInfo.IndexOf(":");
-										var fullClassName = string.Format("{0}.{1}",
-                                                                            classInfo.Substring(colonIndex + 1, classInfo.IndexOf(";") - colonIndex - 1),
-                                                                            reader.LocalName);
-										var assemblyName = classInfo.Substring(classInfo.IndexOf("=") + 1);
-
-										content = CreatePage(fullClassName, assemblyName);
-									}
-									else
-									{
-										content = CreatePage(string.Format("Xamarin.Forms.{0}",reader.LocalName), FormsAssemblyName);
-									}
-								}
-								else
-								{
-									throw new ArgumentException ("Failed to retrieve root element name from XAML");
-								}
-							}
-						}
-
-						if (!string.IsNullOrEmpty (viewModel.Json))
-							content.BindingContext = JsonModel.Parse (viewModel.Json);
-
-						SetPage(content);
-					} 
-					catch (Exception ex) 
-					{
-						SetPage(new ErrorView { ErrorMessage = ex.ToString () });
-						viewModel.Status = ex.Message;
-					}
-				});
-			}
-		}
-
-		/// <summary>
-		/// Used to set MainPage. If page is NavigationPage, existing page is set to root
-		/// </summary>
-		/// <param name="page">Page</param>
-		public void SetPage(Page page)
-		{
-			if (page is NavigationPage)
-			{
-				// If setting to navigation page, 
-				// replace MainPage with Navigation page and push existing page onto stack.
-				var existingPage = MainPage;
-				MainPage = page;
-				MainPage.Navigation.PushAsync(existingPage);
-			}
-			else
-			{
-				// If MainPage is a NavigationPage, reset root
-				if (MainPage is NavigationPage)
-				{
-					var navigation = MainPage.Navigation;
-					navigation.InsertPageBefore(page, navigation.NavigationStack[0]);
-					navigation.PopToRootAsync(false);
-				}
-				else
-				{
-					MainPage = page;
-				}
-			}
-		}
-		
-
-		/// <summary>
-		/// Creates an instance of the page.  If desired type is not an instance of page, a host page will be created
-		/// </summary>
-		/// <param name="fullClassName">Fully qualified class name</param>
-		/// <param name="assemblyName">Assembly name</param>
-		/// <returns>Page instance</returns>
-		private Page CreatePage(string fullClassName, string assemblyName)
-		{
-			Page content;
-
-			var type = Type.GetType(string.Format("{0}, {1}",fullClassName, assemblyName), true);
-
-			// If root type is not a page, create a page and set content to instance of type
-			if (!typeof (Page).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
-			{
-				var view = (View) Activator.CreateInstance(type);
-				view.LoadFromXaml(viewModel.Xaml);
-				
-				var page = new ContentPage {Content = view};
-				content = page;
-			}
-			else
-			{
-				content = (Page) Activator.CreateInstance(type);
-				content.LoadFromXaml(viewModel.Xaml);
-			}
-			return content;
-		}
-
+        
 		/// <summary>
 		/// Starts the app.
 		/// </summary>
 		protected override void OnStart ()
 		{
-			viewModel.Start ();
+			_controller.OnStart();
 		}
 
 		/// <summary>
@@ -161,7 +36,7 @@ namespace Xamarin.Forms.Player
 		/// </summary>
 		protected override void OnSleep ()
 		{
-			viewModel.Sleep ();
+			_controller.OnSleep();
 		}
 
 		/// <summary>
@@ -169,7 +44,7 @@ namespace Xamarin.Forms.Player
 		/// </summary>
 		protected override void OnResume ()
 		{
-			viewModel.Resume ();
+			_controller.OnResume();
 		}
 	}
 }

--- a/src/FormsPlayer/AppController.cs
+++ b/src/FormsPlayer/AppController.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Xml;
+using System.Reflection;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Player
+{
+    /// <summary>
+    /// Main player app controller, to be applied to your main
+    /// Xamarin.Forms application to preserve Styles defined in App.xaml.
+    /// </summary>
+    public class AppController
+    {
+        public Application App { get; private set; }
+        static readonly string FormsAssemblyName = typeof(ContentPage).AssemblyQualifiedName.Substring(typeof(ContentPage).AssemblyQualifiedName.IndexOf(',') + 1).Trim();
+
+        AppViewModel viewModel;
+
+        /// <summary>
+        /// Initializes the application.
+        /// </summary>
+        public AppController(Application app)
+        {
+            App = app;
+            viewModel = new AppViewModel();
+            viewModel.PropertyChanged += OnPropertyChanged;
+
+            SetPage(new MainView { BindingContext = viewModel });
+        }
+
+        private Page MainPage
+        {
+            get { return App.MainPage; }
+            set { App.MainPage = value; }
+        }
+
+        void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            // NOTE: we re-read both XAML and JSON because just re-applying 
+            // the JSON to the BindingContext didn't work reliably.
+            if (e.PropertyName == "Xaml" || e.PropertyName == "Json")
+            {
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    try
+                    {
+                        // Reload view from XAML and model from JSON. 
+                        // Ensures we always refresh both.
+                        var content = MainPage;
+
+                        // We first try to read the root element name from the XAML
+                        if (!string.IsNullOrEmpty(viewModel.Xaml))
+                        {
+                            using (var reader = XmlReader.Create(new StringReader(viewModel.Xaml)))
+                            {
+                                if (reader.MoveToContent() == XmlNodeType.Element)
+                                {
+                                    var rootElement = reader.Name;
+
+                                    // If it contains a colon, then it is not derived from the Xamarin.Forms namespace
+                                    if (rootElement.Contains(":"))
+                                    {
+                                        // Extract the Namespace, class and assembly info
+                                        var classInfo = reader.NamespaceURI;
+
+                                        var colonIndex = classInfo.IndexOf(":");
+                                        var fullClassName = string.Format("{0}.{1}",
+                                                                            classInfo.Substring(colonIndex + 1, classInfo.IndexOf(";") - colonIndex - 1),
+                                                                            reader.LocalName);
+                                        var assemblyName = classInfo.Substring(classInfo.IndexOf("=") + 1);
+
+                                        content = CreatePage(fullClassName, assemblyName);
+                                    }
+                                    else
+                                    {
+                                        content = CreatePage(string.Format("Xamarin.Forms.{0}", reader.LocalName), FormsAssemblyName);
+                                    }
+                                }
+                                else
+                                {
+                                    throw new ArgumentException("Failed to retrieve root element name from XAML");
+                                }
+                            }
+                        }
+
+                        if (!string.IsNullOrEmpty(viewModel.Json))
+                            content.BindingContext = JsonModel.Parse(viewModel.Json);
+
+                        SetPage(content);
+                    }
+                    catch (Exception ex)
+                    {
+                        SetPage(new ErrorView { ErrorMessage = ex.ToString() });
+                        viewModel.Status = ex.Message;
+                    }
+                });
+            }
+        }
+
+        /// <summary>
+        /// Used to set MainPage. If page is NavigationPage, existing page is set to root
+        /// </summary>
+        /// <param name="page">Page</param>
+        public void SetPage(Page page)
+        {
+            if (page is NavigationPage)
+            {
+                // If setting to navigation page, 
+                // replace MainPage with Navigation page and push existing page onto stack.
+                var existingPage = MainPage;
+                MainPage = page;
+                MainPage.Navigation.PushAsync(existingPage);
+            }
+            else
+            {
+                // If MainPage is a NavigationPage, reset root
+                if (MainPage is NavigationPage)
+                {
+                    var navigation = MainPage.Navigation;
+                    navigation.InsertPageBefore(page, navigation.NavigationStack[0]);
+                    navigation.PopToRootAsync(false);
+                }
+                else
+                {
+                    MainPage = page;
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Creates an instance of the page.  If desired type is not an instance of page, a host page will be created
+        /// </summary>
+        /// <param name="fullClassName">Fully qualified class name</param>
+        /// <param name="assemblyName">Assembly name</param>
+        /// <returns>Page instance</returns>
+        private Page CreatePage(string fullClassName, string assemblyName)
+        {
+            Page content;
+
+            var type = Type.GetType(string.Format("{0}, {1}", fullClassName, assemblyName), true);
+
+            // If root type is not a page, create a page and set content to instance of type
+            if (!typeof(Page).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+            {
+                var view = (View)Activator.CreateInstance(type);
+                view.LoadFromXaml(viewModel.Xaml);
+
+                var page = new ContentPage { Content = view };
+                content = page;
+            }
+            else
+            {
+                content = (Page)Activator.CreateInstance(type);
+                content.LoadFromXaml(viewModel.Xaml);
+            }
+            return content;
+        }
+
+        /// <summary>
+        /// Starts the app.
+        /// </summary>
+        public void OnStart()
+        {
+            viewModel.Start();
+        }
+
+        /// <summary>
+        /// Sleeps the app.
+        /// </summary>
+        public void OnSleep()
+        {
+            viewModel.Sleep();
+        }
+
+        /// <summary>
+        /// Resumes the app.
+        /// </summary>
+        public void OnResume()
+        {
+            viewModel.Resume();
+        }
+    }
+}

--- a/src/FormsPlayer/AppViewModel.cs
+++ b/src/FormsPlayer/AppViewModel.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 using System.Windows.Input;
 using Microsoft.AspNet.SignalR.Client;
-using Refractored.Xam.Settings;
+using Plugin.Settings;
 
 namespace Xamarin.Forms.Player
 {

--- a/src/FormsPlayer/FormsPlayer.csproj
+++ b/src/FormsPlayer/FormsPlayer.csproj
@@ -48,12 +48,12 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Refractored.Xam.Settings, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xam.Plugins.Settings.1.5.2\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Refractored.Xam.Settings.dll</HintPath>
+    <Reference Include="Plugin.Settings, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xam.Plugins.Settings.2.1.0\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.Settings.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Refractored.Xam.Settings.Abstractions, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xam.Plugins.Settings.1.5.2\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Refractored.Xam.Settings.Abstractions.dll</HintPath>
+    <Reference Include="Plugin.Settings.Abstractions, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xam.Plugins.Settings.2.1.0\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.Settings.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -91,6 +91,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AppController.cs" />
     <Compile Include="App.cs" />
     <Compile Include="AppViewModel.cs" />
     <Compile Include="ErrorView.xaml.cs">

--- a/src/FormsPlayer/Helpers/Settings.cs
+++ b/src/FormsPlayer/Helpers/Settings.cs
@@ -1,6 +1,6 @@
 // Helpers/Settings.cs
-using Refractored.Xam.Settings;
-using Refractored.Xam.Settings.Abstractions;
+using Plugin.Settings;
+using Plugin.Settings.Abstractions;
 
 namespace Xamarin.Forms.Player.Helpers
 {
@@ -31,11 +31,11 @@ namespace Xamarin.Forms.Player.Helpers
     {
       get
       {
-        return AppSettings.GetValueOrDefault(SettingsKey, SettingsDefault);
+        return AppSettings.GetValueOrDefault<string>(SettingsKey, SettingsDefault);
       }
       set
       {
-        AppSettings.AddOrUpdateValue(SettingsKey, value);
+        AppSettings.AddOrUpdateValue<string>(SettingsKey, value);
       }
     }
 

--- a/src/FormsPlayer/packages.config
+++ b/src/FormsPlayer/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable-monoandroid1+monotouch1+net45+win+wp8+xamarinios1" userInstalled="true" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable-monoandroid1+monotouch1+net45+win+wp8+xamarinios1" userInstalled="true" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" userInstalled="true" />
-  <package id="Xam.Plugins.Settings" version="1.5.2" targetFramework="portable45-net45+win8+wp8" userInstalled="true" />
+  <package id="Xam.Plugins.Settings" version="2.1.0" targetFramework="portable45-net45+win8+wp8" userInstalled="true" />
   <package id="Xamarin.Forms" version="1.5.0.6447" targetFramework="portable45-net45+win8+wp8" />
   <package id="Xamarin.Forms.Dynamic" version="0.1.17-pre" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/src/Xamarin.Forms.Player.nuspec
+++ b/src/Xamarin.Forms.Player.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Xamarin.Forms.Player</id>
-		<version>0.1.8-pre</version>
+		<version>0.1.12-pre</version>
 		<authors>Daniel Cazzulino</authors>
 		<owners>Daniel Cazzulino</owners>
 		<licenseUrl>http://www.mobileessentials.org/license</licenseUrl>
@@ -12,12 +12,12 @@
 		<description>Preview Xamarin.Forms XAML on devices and simulators, with support for data-binding via JSON dummy view models.</description>
 		<copyright />
 		<dependencies>
-			<dependency id="Microsoft.AspNet.SignalR.Client" version="2.2.0"  />
+			<dependency id="Microsoft.Bcl.Build" version="1.0.21" />
 			<dependency id="Microsoft.Net.Http" version="2.2.28" />
 			<dependency id="Newtonsoft.Json" version="6.0.8" />
 			<dependency id="Xamarin.Forms" version="1.4.3.6358-pre2" />
-			<dependency id="Xamarin.Forms.Dynamic" version="0.1.13-pre" />
-			<dependency id="Xam.Plugins.Settings" version="1.5.1" />
+			<dependency id="Xamarin.Forms.Dynamic" version="0.1.18-pre" />
+			<dependency id="Xam.Plugins.Settings" version="2.1.0" />
 		</dependencies>
 	</metadata>
 	<files>


### PR DESCRIPTION
Also updated Xam.Plugins.Settings to version 2 (otherwise there are build errors, because 2.0 isn't compatible with 1.5). 
Changed nuspec file to ease the installation (Microsoft.AspNet.SignalR.Client is not installable to the default Xamarin.Forms templates projects). Added an instruction to readme on how to fully utilize the new configuration
